### PR TITLE
Docker builds

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - docker-builds
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -16,6 +17,7 @@ env:
     DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
     IMAGE_NAME: ${{ secrets.DOCKER_USERNAME }}/emtk
 
+jobs:
     build-docker:
       name: build-docker
       runs-on: ubuntu-24.04

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - docker-builds
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,42 @@
+name: Docker build and push
+
+on:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+    RUST_VERSION: '1.85.1'
+
+    DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+    DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+    IMAGE_NAME: ${{ secrets.DOCKER_USERNAME }}/emtk
+
+    build-docker:
+      name: build-docker
+      runs-on: ubuntu-24.04
+      steps:
+        - name: Checkout sources
+          uses: actions/checkout@v4
+        - name: Dockerhub login
+          run: |
+            echo "${DOCKER_PASSWORD}" | docker login --username ${DOCKER_USERNAME} --password-stdin
+        - name: Setup QEMU
+          uses: docker/setup-qemu-action@v3
+        - name: Setup Buildx
+          uses: docker/setup-buildx-action@v3
+
+        - name: Build and push
+          uses: docker/build-push-action@v6
+          with:
+            platforms: linux/amd64,linux/arm64
+            push: true
+            tags: |
+              ${{ env.IMAGE_NAME }}
+            build-args: |
+              RUST_VERSION=${{ env.RUST_VERSION }}
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+ARG RUST_VERSION=1.85.1
+FROM rust:${RUST_VERSION}-bookworm AS builder
+RUN apt update && apt dist-upgrade -y && apt install -y cmake libclang-dev
+COPY . emtk
+ARG PROFILE=release
+ENV PROFILE=$PROFILE
+RUN cd emtk && make
+
+FROM debian:bookworm-slim
+ENTRYPOINT ["/usr/local/bin/emtk"]
+RUN apt update && apt dist-upgrade -y \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
+COPY --from=builder /usr/local/cargo/bin/emtk /usr/local/bin/emtk


### PR DESCRIPTION
needs 2 repo secrets: 
- `DOCKER_USERNAME` 
- `DOCKER_PASSWORD`

it [works fine](https://hub.docker.com/r/antondlr/emtk/tags) but is [kinda slow](https://github.com/antondlr/eth-mnemonic-to-keystore/actions/runs/14092302686/job/39471731539)

if you prefer not to publish to our docker `sigp` namespace, we can use another one